### PR TITLE
remove apiextensions.k8s.io/v1beta1 for crd as api is removed in openshift 4.9 release

### DIFF
--- a/charts/konfigurator/templates/crd.yaml
+++ b/charts/konfigurator/templates/crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployCRD }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: konfiguratortemplates.konfigurator.stakater.com
@@ -13,7 +13,7 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: podmetadatainjectors.konfigurator.stakater.com


### PR DESCRIPTION
remove apiextensions.k8s.io/v1beta1 for customresourcedefinitions as api is removed in openshift 4.9 release